### PR TITLE
remove deprecated colorschemer plugin

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -153,7 +153,6 @@ parts:
       - -Dplugin_charmap=true
       - -Dplugin_codecomment=true
       - -Dplugin_colorpicker=true
-      - -Dplugin_colorschemer=true
       - -Dplugin_drawspaces=true
       - -Dplugin_git=true
       - -Dplugin_joinlines=true


### PR DESCRIPTION
colorschemer plugin was deprecated by https://gitlab.gnome.org/GNOME/gedit-plugins/-/commit/344b15528e133a0f7b7f4fd496612e8596a0a48c and this is causing the build to fail.
Removing it 