### PR TITLE
deps: limit gedit part to v46

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -111,7 +111,10 @@ parts:
   gedit:
     after: [ gedit-gtksourceview, amtk, tepl ]
     source: https://gitlab.gnome.org/GNOME/gedit.git
-    source-tag: '47.0'
+    source-tag: '46.2'
+# ext:updatesnap
+#   version-format:
+#     lower-than: 47
     source-depth: 1
     source-type: git
     parse-info: [usr/share/metainfo/org.gnome.gedit.appdata.xml]


### PR DESCRIPTION
gedit is failing because the automation bumped to a devel tag and one of the dependencies isn't ready. Limiting to a stable tag should fix the issue